### PR TITLE
Improve auth flexibility

### DIFF
--- a/src/components/authentication/LoginButton.tsx
+++ b/src/components/authentication/LoginButton.tsx
@@ -1,5 +1,5 @@
 import { StyleSheet, View } from 'react-native';
-import { msalIsConnected, msalLogin } from '../../services/auth';
+import { isMsalConnected, msalLogin } from '../../services/auth';
 
 import Button from '../common/atoms/Button';
 import React from 'react';
@@ -14,7 +14,7 @@ export default function LoginButton(props: {
   return (
     <View>
       <Button
-        disabled={!msalIsConnected()}
+        disabled={!isMsalConnected()}
         title="Login"
         onPress={async () => {
           msalLogin(props.scope).then(() =>

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -5,7 +5,7 @@ import LoginButton from '../components/authentication/LoginButton';
 import { authenticateSilently } from '../services/auth';
 import colors from '../stylesheets/colors';
 import equinorLogo from '../resources/images/equinor_logo.png';
-import { msalIsConnected } from '../services/auth';
+import { isMsalConnected } from '../services/auth';
 import { Typography } from '../components/common';
 
 //import * as WebBrowser from 'expo-web-browser';
@@ -20,7 +20,7 @@ export default function LoginScreen(props: {
   logo: any;
 }) {
   useEffect(() => {
-    msalIsConnected() &&
+    isMsalConnected() &&
       authenticateSilently(props.scope)
         .catch((e) => console.warn(e))
         .then((res) => res && props.navigation.navigate(props.mainRoute));

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -3,21 +3,15 @@ import PublicClientApplication, { MSALAccount, MSALResult, MSALSilentParams } fr
 import type {
   MSALConfiguration,
 } from "react-native-msal";
-import { Platform } from "react-native";
-
-//import { Platform } from "react-native";
 
 export let pca: PublicClientApplication | null = null;
 
-export async function msalInit(clientId: string, redirectUri: string, authority?: string) {
-
+export async function msalInit(authority: string, clientId: string, redirectUri: string) {
   const config: MSALConfiguration = {
     auth: {
+        authority: authority,
         clientId: clientId,
-        authority: authority ? authority : "https://login.microsoftonline.com/statoilsrm.onmicrosoft.com/",
-        redirectUri: Platform.OS === 'web' ? 'http://localhost:19006' : `msauth.${redirectUri}://auth`,
-        // redirectUri: 'http://localhost:19006'
-        // knownAuthorities: ["https://login.microsoftonline.com/statoilsrm.onmicrosoft.com/"]
+        redirectUri: redirectUri,
     },
     cache: { cacheLocation: 'localStorage' },
   };
@@ -25,18 +19,18 @@ export async function msalInit(clientId: string, redirectUri: string, authority?
   await pca.init().catch(e => console.warn(e));
 }
 
-export function msalIsConnected(): boolean {
+export function isMsalConnected(): boolean {
     return !!pca;
 }
 
 
-export async function msalLogin(scope: string) {
+export async function msalLogin(scopes: string[]) {
   if (!pca) {
     throw new Error(
       "Unable to authenticate, pca is null"
     );
   }
-  const result: MSALResult | undefined = await pca.acquireToken({ scopes: [scope] });
+  const result: MSALResult | undefined = await pca.acquireToken({ scopes: scopes });
   return { ...result?.account, userId:  result?.account.username};
   
 }
@@ -58,7 +52,7 @@ export async function getAccount() {
   return null;
 }
 
-export async function authenticateSilently(scope: string) {
+export async function authenticateSilently(scopes: string[]) {
   if (!pca) {
     throw new Error(
       "Unable to authenticate, pca is null"
@@ -71,7 +65,7 @@ export async function authenticateSilently(scope: string) {
     const account = accounts[0]
     const params: MSALSilentParams = {
       account: accounts[0],
-      scopes: [scope],
+      scopes: scopes,
       forceRefresh: false
     };
     const result: MSALResult | undefined | void = await pca.acquireTokenSilent(params).catch((e) => {console.log("Error while fetching token silently", e)}).then(res => res);

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,51 +1,51 @@
-
-import PublicClientApplication, { MSALAccount, MSALResult, MSALSilentParams } from "react-native-msal";
-import type {
-  MSALConfiguration,
+import PublicClientApplication, {
+  MSALAccount,
+  MSALResult,
+  MSALSilentParams,
 } from "react-native-msal";
+import type { MSALConfiguration } from "react-native-msal";
 
 export let pca: PublicClientApplication | null = null;
 
-export async function msalInit(clientId: string, redirectUri: string, authority?: string,) {
+export async function msalInit(
+  clientId: string,
+  redirectUri: string,
+  authority = "https://login.microsoftonline.com/statoilsrm.onmicrosoft.com/"
+) {
   const config: MSALConfiguration = {
     auth: {
-        authority: authority ? authority : "https://login.microsoftonline.com/statoilsrm.onmicrosoft.com/",
-        clientId: clientId,
-        redirectUri: redirectUri,
+      authority,
+      clientId,
+      redirectUri,
     },
-    cache: { cacheLocation: 'localStorage' },
+    cache: { cacheLocation: "localStorage" },
   };
   pca = new PublicClientApplication(config);
-  await pca.init().catch(e => console.warn(e));
+  await pca.init().catch((e) => console.warn(e));
 }
 
 export function isMsalConnected(): boolean {
-    return !!pca;
+  return !!pca;
 }
-
 
 export async function msalLogin(scopes: string[]) {
   if (!pca) {
-    throw new Error(
-      "Unable to authenticate, pca is null"
-    );
+    throw new Error("Unable to authenticate, pca is null");
   }
-  const result: MSALResult | undefined = await pca.acquireToken({ scopes: scopes });
-  return { ...result?.account, userId:  result?.account.username};
-  
+  const result: MSALResult | undefined = await pca.acquireToken({
+    scopes,
+  });
+  return { ...result?.account, userId: result?.account.username };
 }
-
 
 export async function getAccount() {
   if (!pca) {
-    throw new Error(
-      "Unable to authenticate, pca is null"
-    );
+    throw new Error("Unable to authenticate, pca is null");
   }
   const accounts: MSALAccount[] = await pca.getAccounts();
 
   if (accounts.length > 0) {
-    const account = accounts[0]
+    const account = accounts[0];
     return account;
   }
 
@@ -54,23 +54,29 @@ export async function getAccount() {
 
 export async function authenticateSilently(scopes: string[]) {
   if (!pca) {
-    throw new Error(
-      "Unable to authenticate, pca is null"
-    );
+    throw new Error("Unable to authenticate, pca is null");
   }
 
-  const accounts: MSALAccount[] | void = await pca.getAccounts().catch(e => console.warn(e)).then(accounts => accounts);
+  const accounts: MSALAccount[] | void = await pca
+    .getAccounts()
+    .catch((e) => console.warn(e))
+    .then((accounts) => accounts);
 
   if (accounts && accounts.length > 0) {
-    const account = accounts[0]
+    const account = accounts[0];
     const params: MSALSilentParams = {
       account: accounts[0],
-      scopes: scopes,
-      forceRefresh: false
+      scopes,
+      forceRefresh: false,
     };
-    const result: MSALResult | undefined | void = await pca.acquireTokenSilent(params).catch((e) => {console.log("Error while fetching token silently", e)}).then(res => res);
-    if (!result) return null
-    return { ...result, userId: account.username};
+    const result: MSALResult | undefined | void = await pca
+      .acquireTokenSilent(params)
+      .catch((e) => {
+        console.log("Error while fetching token silently", e);
+      })
+      .then((res) => res);
+    if (!result) return null;
+    return { ...result, userId: account.username };
   }
 
   throw Error("No refresh token, can't authenticate silently");
@@ -80,9 +86,7 @@ export const errorCodes = {};
 
 export async function logout() {
   if (!pca) {
-    throw new Error(
-      "Unable to logout, pca is null"
-    );
+    throw new Error("Unable to logout, pca is null");
   }
   const accounts: MSALAccount[] = await pca.getAccounts();
 

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -6,10 +6,10 @@ import type {
 
 export let pca: PublicClientApplication | null = null;
 
-export async function msalInit(authority: string, clientId: string, redirectUri: string) {
+export async function msalInit(clientId: string, redirectUri: string, authority?: string,) {
   const config: MSALConfiguration = {
     auth: {
-        authority: authority,
+        authority: authority ? authority : "https://login.microsoftonline.com/statoilsrm.onmicrosoft.com/",
         clientId: clientId,
         redirectUri: redirectUri,
     },


### PR DESCRIPTION
Make auth more flexible and usable by the public.

- `msalIsConnected` was renamed to `isMsalConnected`for better readability
- Now allowing more than 1 scope in functions with `scope`-prop
## msalInit-function
- `redirectUri`is now managed outside of the `msalInit`-function

Closes #57 