### PR TITLE
feat: change passed onSubmit function to run in addition to default

### DIFF
--- a/src/screens/OnBoardingScreen.tsx
+++ b/src/screens/OnBoardingScreen.tsx
@@ -104,7 +104,8 @@ const OnBoardingScreen = (props: {
         title="Submit"
         onPress={() => {
           {config.map((inputConfig) => {
-          inputConfig.onSubmit ? inputConfig.onSubmit(onboardingSettings) : storeData(onboardingSettings);;
+          inputConfig.onSubmit ? inputConfig.onSubmit(onboardingSettings) : ()=>{};
+          storeData(onboardingSettings);
           props.navigation.replace(props.onSubmitRoute ?? 'Root');
           })}
         }}


### PR DESCRIPTION
Instead of overriding the onSubmit function, the onSubmit from OnboardingConfig now runs in addition to the default onSubmit function in mad-expo-core OnboardingScreen.

