### PR TITLE
271 add release notes to the app

### DIFF
--- a/src/components/common/organisms/ChangeLog.tsx
+++ b/src/components/common/organisms/ChangeLog.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { View, Text, Button, ScrollView, StyleSheet, Pressable } from 'react-native';
+import Spinner from '../atoms/Spinner';
+import Colors from 'src/stylesheets/colors';
+
+const featureTitle = "What's new";
+const affirmText = 'OK';
+
+const ChangeLog = (props: {
+    releaseNote: string;
+    fetching: boolean;
+    affirm: any;
+  }) => {
+
+  const renderChangeLog = (release) => {
+    const { changelogItem, subtitleHeader, changelogText, bullet, bulletList } = styles;
+
+    const changes = release.changes || [];
+    return (
+      <ScrollView style={changelogItem}>
+        <Text style={subtitleHeader}>{release.header}</Text>
+        <Text style={changelogText}>{release.subHeader}</Text>
+        <View style={{ margin: 5, marginLeft: 10 }}>
+          {changes.map((change, index) => (
+            <View key={index.toString()} style={bulletList}>
+              <Text style={bullet}>{'\u2022'}</Text>
+              <Text style={changelogText}>{change}</Text>
+            </View>
+          ))}
+        </View>
+      </ScrollView>
+    );
+  }
+
+  
+  const { container, footer, titleHeader, buttonStyle } = styles;
+
+  const { releaseNote, affirm, fetching } = props;
+
+  if (fetching) {
+    return <Spinner />;
+  }
+
+  return (
+    <View style={container}>
+      <Text style={titleHeader}>{featureTitle}</Text>
+      {renderChangeLog(releaseNote)}
+      <View style={footer}>
+        <Pressable style={buttonStyle} onPress={affirm}>
+          <Text>{affirmText}</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 50,
+    justifyContent: 'center',
+    backgroundColor: Colors.GRAY_4,
+  },
+  footer: {
+    height: 50,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderColor: Colors.GRAY_2,
+    borderTopWidth: 0.5,
+  },
+  titleHeader: {
+    marginVertical: 15,
+    alignSelf: 'center',
+    fontWeight: '500',
+    fontSize: 30,
+    color: Colors.GRAY_1,
+  },
+  subtitleHeader: {
+    fontSize: 20,
+    marginVertical: 5,
+    color: Colors.GRAY_1,
+  },
+  changelogText: {
+    fontSize: 16,
+    marginVertical: 1,
+    color: Colors.GRAY_1,
+  },
+  bullet: {
+    fontSize: 16,
+    marginVertical: 1,
+    marginRight: 5,
+    color: Colors.GRAY_1,
+  },
+  buttonStyle: {
+    backgroundColor: '#0288D1',
+    margin: 20,
+  },
+  bulletList: {
+    flexDirection: 'row',
+  },
+  changelogItem: {
+    marginBottom: 15,
+    marginTop: 20,
+    paddingHorizontal: 20,
+  },
+});
+
+export default ChangeLog;

--- a/src/components/common/organisms/ChangeLog.tsx
+++ b/src/components/common/organisms/ChangeLog.tsx
@@ -13,7 +13,7 @@ const ChangeLog = (props: {
     affirm: any;
   }) => {
 
-  const renderChangeLog = (release) => {
+  const renderChangeLog = (release : any) => {
     const { changelogItem, subtitleHeader, changelogText, bullet, bulletList } = styles;
 
     const changes = release.changes || [];
@@ -22,7 +22,7 @@ const ChangeLog = (props: {
         <Text style={subtitleHeader}>{release.header}</Text>
         <Text style={changelogText}>{release.subHeader}</Text>
         <View style={{ margin: 5, marginLeft: 10 }}>
-          {changes.map((change, index) => (
+          {changes.map((change: boolean | React.ReactChild | React.ReactFragment | React.ReactPortal | null | undefined, index: { toString: () => React.Key | null | undefined; }) => (
             <View key={index.toString()} style={bulletList}>
               <Text style={bullet}>{'\u2022'}</Text>
               <Text style={changelogText}>{change}</Text>

--- a/src/components/common/organisms/ChangeLog.tsx
+++ b/src/components/common/organisms/ChangeLog.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, Button, ScrollView, StyleSheet, Pressable } from 'react-native';
+import { View, Text, ScrollView, StyleSheet, Pressable } from 'react-native';
 import Spinner from '../atoms/Spinner';
 import Colors from 'src/stylesheets/colors';
 

--- a/src/components/common/organisms/ChangeLog.tsx
+++ b/src/components/common/organisms/ChangeLog.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { View, Text, ScrollView, StyleSheet, Pressable } from 'react-native';
+import { View, Text, ScrollView, StyleSheet } from 'react-native';
+import Button from '../atoms/Button';
 import Spinner from '../atoms/Spinner';
-import Colors from 'src/stylesheets/colors';
+import Colors from "../../../stylesheets/colors";
 
 const featureTitle = "What's new";
 const affirmText = 'OK';
@@ -33,7 +34,7 @@ const ChangeLog = (props: {
   }
 
   
-  const { container, footer, titleHeader, buttonStyle } = styles;
+  const { container, footer, titleHeader} = styles;
 
   const { releaseNote, affirm, fetching } = props;
 
@@ -46,9 +47,10 @@ const ChangeLog = (props: {
       <Text style={titleHeader}>{featureTitle}</Text>
       {renderChangeLog(releaseNote)}
       <View style={footer}>
-        <Pressable style={buttonStyle} onPress={affirm}>
-          <Text>{affirmText}</Text>
-        </Pressable>
+        <Button
+          title={affirmText}
+          onPress={affirm}
+        />
       </View>
     </View>
   );
@@ -63,7 +65,7 @@ const styles = StyleSheet.create({
     backgroundColor: Colors.GRAY_4,
   },
   footer: {
-    height: 50,
+    height: 80,
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
@@ -92,10 +94,6 @@ const styles = StyleSheet.create({
     marginVertical: 1,
     marginRight: 5,
     color: Colors.GRAY_1,
-  },
-  buttonStyle: {
-    backgroundColor: '#0288D1',
-    margin: 20,
   },
   bulletList: {
     flexDirection: 'row',

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import LoginButton from './components/authentication/LoginButton';
 import LoginScreen from './screens/LoginScreen';
 import OnBoardingScreen from './screens/OnBoardingScreen';
 import Radiobutton from './components/common/atoms/Radiobutton';
+import ReleaseNoteScreen from './screens/ReleaseNoteScreen';
 import SettingsButton from './components/common/molecules/SettingsButton';
 import SettingsScreen from './screens/SettingsScreen';
 
@@ -41,6 +42,7 @@ export {
   FeedbackScreen,
   LoginScreen,
   OnBoardingScreen,
+  ReleaseNoteScreen,
   SettingsScreen,
   msalInit,
   msalLogin,

--- a/src/resources/mock-data.json
+++ b/src/resources/mock-data.json
@@ -1,0 +1,11 @@
+{
+    "ReleaseNotes": {
+        "header": "New features and fixes",
+        "subHeader": "v0.2.0 ( 29.08.22)",
+        "changes": [
+          "Added some new features",
+          "Fixed a few bugs",
+          "Improved performance"
+        ]
+      }
+}

--- a/src/screens/ReleaseNoteScreen.tsx
+++ b/src/screens/ReleaseNoteScreen.tsx
@@ -1,0 +1,53 @@
+import React, { useEffect } from 'react';
+
+import { useState } from 'react';
+import ChangeLog from 'src/components/common/organisms/ChangeLog';
+import * as mockData from '../resources/mock-data.json';
+
+
+const ReleaseNoteScreen = (props: {
+  name: string;
+  version: string;
+  environment: 'dev' | 'test' | 'qa' | 'prod';
+  navigation: any;
+  demoMode?: boolean;
+  languageCode?: string;
+}) => {
+  const [releaseNote, setReleaseNote] = useState(Object);
+  const [error, setError] = useState('');
+  const [fetching, setFetching] = useState(true);
+
+  useEffect(() => {
+    const fetchChangelog = (() => {
+      const environment = props.environment === 'prod' ? `` : `${props.environment}/`;
+      if(props.demoMode){
+        setReleaseNote(mockData.ReleaseNotes);
+      } else{
+          fetch(
+            `https://api.statoil.com/app/mad/${environment}api/v1/ReleaseNote/${props.name}/${props.version}`
+          )
+            .then((res) => res.json().then((data) => {
+              setReleaseNote(data);
+              setFetching(false);
+            }))
+            .catch((error) => {
+              setError(error);
+              setFetching(false);
+              }
+            );
+      }
+    });
+
+    fetchChangelog();
+  }, []);
+
+  if(error){ 
+    props.navigation.navigate('Root');
+  };
+
+  return (
+    <ChangeLog releaseNote={releaseNote} fetching={fetching} affirm={() => props.navigation.navigate('Root')} />
+  );
+};
+
+export default ReleaseNoteScreen;

--- a/src/screens/ReleaseNoteScreen.tsx
+++ b/src/screens/ReleaseNoteScreen.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 
 import { useState } from 'react';
-import ChangeLog from 'src/components/common/organisms/ChangeLog';
+import ChangeLog from '../components/common/organisms/ChangeLog';
 import * as mockData from '../resources/mock-data.json';
 
 
@@ -22,6 +22,7 @@ const ReleaseNoteScreen = (props: {
       const environment = props.environment === 'prod' ? `` : `${props.environment}/`;
       if(props.demoMode){
         setReleaseNote(mockData.ReleaseNotes);
+        setFetching(false);
       } else{
           fetch(
             `https://api.statoil.com/app/mad/${environment}api/v1/ReleaseNote/${props.name}/${props.version}`

--- a/src/screens/ReleaseNoteScreen.tsx
+++ b/src/screens/ReleaseNoteScreen.tsx
@@ -1,4 +1,6 @@
+import { authenticateSilently } from '../services/auth';
 import React, { useEffect } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 import { useState } from 'react';
 import ChangeLog from '../components/common/organisms/ChangeLog';
@@ -9,7 +11,9 @@ const ReleaseNoteScreen = (props: {
   name: string;
   version: string;
   environment: 'dev' | 'test' | 'qa' | 'prod';
+  scope: string;
   navigation: any;
+  versionStorageKey: string;
   demoMode?: boolean;
   languageCode?: string;
 }) => {
@@ -17,37 +21,68 @@ const ReleaseNoteScreen = (props: {
   const [error, setError] = useState('');
   const [fetching, setFetching] = useState(true);
 
+  const storeData = async (value: string | null) => {
+    try {
+      if (value) {
+        await AsyncStorage.setItem("version", value);
+      } else {
+        await AsyncStorage.removeItem("version");
+      }
+    } catch (e) {
+      // saving error
+    }
+  };
+
   useEffect(() => {
+
+    const checkVersion = async () => {
+      try {
+        const version = await AsyncStorage.getItem("version");
+        if (version === props.version) {
+          props.navigation.navigate('Root');
+        }
+      } catch (e) {
+        // error reading value
+      }
+    };
+
     const fetchChangelog = (() => {
       const environment = props.environment === 'prod' ? `` : `${props.environment}/`;
       if(props.demoMode){
         setReleaseNote(mockData.ReleaseNotes);
         setFetching(false);
       } else{
-          fetch(
-            `https://api.statoil.com/app/mad/${environment}api/v1/ReleaseNote/${props.name}/${props.version}`
-          )
+          authenticateSilently([props.scope]).then(response => {
+            fetch(`https://api.statoil.com/app/mad/${environment}api/v1/ReleaseNote/${props.name}/${props.version}`, { 
+            method: 'GET', 
+            headers: new Headers({
+                'Authorization': response ? `Bearer ${response.accessToken}` : "", 
+            }),
+          })
             .then((res) => res.json().then((data) => {
               setReleaseNote(data);
               setFetching(false);
             }))
-            .catch((error) => {
-              setError(error);
-              setFetching(false);
-              }
-            );
+          }).catch((error) => {
+            setError(error);
+            setFetching(false);
+            }
+          );
       }
     });
-
+    
+    checkVersion();
     fetchChangelog();
   }, []);
-
   if(error){ 
     props.navigation.navigate('Root');
   };
 
   return (
-    <ChangeLog releaseNote={releaseNote} fetching={fetching} affirm={() => props.navigation.navigate('Root')} />
+    <ChangeLog releaseNote={releaseNote} fetching={fetching} affirm={() => { 
+      storeData(props.version);
+      props.navigation.navigate('Root')
+    }} />
   );
 };
 

--- a/src/screens/ReleaseNoteScreen.tsx
+++ b/src/screens/ReleaseNoteScreen.tsx
@@ -62,7 +62,10 @@ const ReleaseNoteScreen = (props: {
             .then((res) => res.json().then((data) => {
               setReleaseNote(data);
               setFetching(false);
-            }))
+            })).catch((error) => {
+              setError(error);
+              setFetching(false);
+            })
           }).catch((error) => {
             setError(error);
             setFetching(false);

--- a/src/screens/ReleaseNoteScreen.tsx
+++ b/src/screens/ReleaseNoteScreen.tsx
@@ -24,9 +24,9 @@ const ReleaseNoteScreen = (props: {
   const storeData = async (value: string | null) => {
     try {
       if (value) {
-        await AsyncStorage.setItem("version", value);
+        await AsyncStorage.setItem(props.versionStorageKey, value);
       } else {
-        await AsyncStorage.removeItem("version");
+        await AsyncStorage.removeItem(props.versionStorageKey);
       }
     } catch (e) {
       // saving error
@@ -35,18 +35,18 @@ const ReleaseNoteScreen = (props: {
 
   useEffect(() => {
 
-    const checkVersion = async () => {
+    const fetchChangelog = (async () => {
+
       try {
-        const version = await AsyncStorage.getItem("version");
+        const version = await AsyncStorage.getItem(props.versionStorageKey);
         if (version === props.version) {
-          props.navigation.navigate('Root');
+          setFetching(false)
+          return;
         }
       } catch (e) {
         // error reading value
       }
-    };
 
-    const fetchChangelog = (() => {
       const environment = props.environment === 'prod' ? `` : `${props.environment}/`;
       if(props.demoMode){
         setReleaseNote(mockData.ReleaseNotes);
@@ -71,19 +71,19 @@ const ReleaseNoteScreen = (props: {
       }
     });
     
-    checkVersion();
     fetchChangelog();
   }, []);
-  if(error){ 
+  if(error || (!fetching && !releaseNote.changes)){ 
     props.navigation.navigate('Root');
-  };
-
-  return (
-    <ChangeLog releaseNote={releaseNote} fetching={fetching} affirm={() => { 
-      storeData(props.version);
-      props.navigation.navigate('Root')
-    }} />
-  );
+    return <></>;
+  } else {
+    return (
+      <ChangeLog releaseNote={releaseNote} fetching={fetching} affirm={() => { 
+        storeData(props.version);
+        props.navigation.navigate('Root')
+      }} />
+    );
+  }
 };
 
 export default ReleaseNoteScreen;


### PR DESCRIPTION
allows apps to display changelog whenever a new version is installed. The changes are shown only once before navigating to root and then wont show new changes until the app is updated again.