### PR TITLE
chore: Remove unused peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,6 @@
         "@react-navigation/native": ">=5.8.10",
         "@react-navigation/stack": ">=5.12.8",
         "expo": ">=45.0.0",
-        "expo-font": "^10.0.5",
         "expo-localization": "*",
         "expo-random": "*",
         "react": "*",
@@ -11614,18 +11613,6 @@
       "integrity": "sha512-MYYDKxjLo9VOkvGHqym5EOAUS+ero9O66X5zI+EXJzqNznKvnfScdXeeAaQzShmWtmLkdVDCoYFGOaTvTA1wTQ==",
       "dependencies": {
         "uuid": "^3.4.0"
-      },
-      "peerDependencies": {
-        "expo": "*"
-      }
-    },
-    "node_modules/expo-font": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-10.2.1.tgz",
-      "integrity": "sha512-sxy5GrdtY+Ka8Wo5wnrcFFeO6MbYC6Dris5wMLqshvVK6BneJNMUsFvwRfvVgg0TzsmMAc3Rlca2xyZ8ettinw==",
-      "peer": true,
-      "dependencies": {
-        "fontfaceobserver": "^2.1.0"
       },
       "peerDependencies": {
         "expo": "*"
@@ -34268,15 +34255,6 @@
       "integrity": "sha512-MYYDKxjLo9VOkvGHqym5EOAUS+ero9O66X5zI+EXJzqNznKvnfScdXeeAaQzShmWtmLkdVDCoYFGOaTvTA1wTQ==",
       "requires": {
         "uuid": "^3.4.0"
-      }
-    },
-    "expo-font": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-10.2.1.tgz",
-      "integrity": "sha512-sxy5GrdtY+Ka8Wo5wnrcFFeO6MbYC6Dris5wMLqshvVK6BneJNMUsFvwRfvVgg0TzsmMAc3Rlca2xyZ8ettinw==",
-      "peer": true,
-      "requires": {
-        "fontfaceobserver": "^2.1.0"
       }
     },
     "expo-keep-awake": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "@react-navigation/native": ">=5.8.10",
     "@react-navigation/stack": ">=5.12.8",
     "expo": ">=45.0.0",
-    "expo-font": "^10.0.5",
     "expo-localization": "*",
     "expo-random": "*",
     "react": "*",


### PR DESCRIPTION
Removes expo-font from peerDependencies since it's not in use.

Closes #134